### PR TITLE
New contact link

### DIFF
--- a/docs/overview/contact.md
+++ b/docs/overview/contact.md
@@ -14,4 +14,4 @@ If you have questions about Hgraph, looking to partner with us or are interested
 - [Add Hgraph on LinkedIn →](https://www.linkedin.com/company/hgraph_io)
 - [Contribute on GitHub →](https://github.com/hgraph-io)
 
-Interested in working with Hgraph? [Please use this form →](https://form.typeform.com/to/LUnKkmRL)
+Interested in working with Hgraph? [Please use this form →](https://hgraph.com/contact)


### PR DESCRIPTION
Removed the typeform links and replaced with our new contact page.