### PR TITLE
Reorder Hedera Stats pages

### DIFF
--- a/docs/hedera-stats/active-accounts.md
+++ b/docs/hedera-stats/active-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 15
 title: Active Accounts
 ---
 

--- a/docs/hedera-stats/active-contracts.md
+++ b/docs/hedera-stats/active-contracts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 22
 title: Active Contracts
 ---
 

--- a/docs/hedera-stats/active-ecdsa-accounts.md
+++ b/docs/hedera-stats/active-ecdsa-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 16
 title: Active ECDSA Accounts
 ---
 

--- a/docs/hedera-stats/active-ed25519-accounts.md
+++ b/docs/hedera-stats/active-ed25519-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 17
 title: Active ED25519 Accounts
 ---
 

--- a/docs/hedera-stats/developer-accounts.md
+++ b/docs/hedera-stats/developer-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 18
 title: Developer Accounts
 ---
 

--- a/docs/hedera-stats/misc.md
+++ b/docs/hedera-stats/misc.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 23
 title: Misc
 ---
 

--- a/docs/hedera-stats/new-accounts.md
+++ b/docs/hedera-stats/new-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 12
 title: New Accounts
 ---
 

--- a/docs/hedera-stats/new-ecdsa-accounts.md
+++ b/docs/hedera-stats/new-ecdsa-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 13
 title: New ECDSA Accounts
 ---
 

--- a/docs/hedera-stats/new-ed25519-accounts.md
+++ b/docs/hedera-stats/new-ed25519-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 14
 title: New ED25519 Accounts
 ---
 

--- a/docs/hedera-stats/new-smart-contracts.md
+++ b/docs/hedera-stats/new-smart-contracts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 21
 title: New Smart Contracts
 ---
 

--- a/docs/hedera-stats/retail-accounts.md
+++ b/docs/hedera-stats/retail-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 19
 title: Retail Accounts
 ---
 

--- a/docs/hedera-stats/revenue.md
+++ b/docs/hedera-stats/revenue.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 title: Network Revenue
 ---
 

--- a/docs/hedera-stats/stablecoin-market-cap.md
+++ b/docs/hedera-stats/stablecoin-market-cap.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 4
 ---
 
 # Stablecoin Market Cap

--- a/docs/hedera-stats/time-to-consensus.md
+++ b/docs/hedera-stats/time-to-consensus.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 8
 title: Time to Consensus
 ---
 

--- a/docs/hedera-stats/total-accounts.md
+++ b/docs/hedera-stats/total-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 9
 title: Total Accounts
 ---
 

--- a/docs/hedera-stats/total-ecdsa-accounts.md
+++ b/docs/hedera-stats/total-ecdsa-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 10
 title: Total ECDSA Accounts
 ---
 

--- a/docs/hedera-stats/total-ed25519-accounts.md
+++ b/docs/hedera-stats/total-ed25519-accounts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 11
 title: Total ED25519 Accounts
 ---
 

--- a/docs/hedera-stats/total-smart-contracts.md
+++ b/docs/hedera-stats/total-smart-contracts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 20
 title: Total Smart Contracts
 ---
 

--- a/docs/hedera-stats/total-value-locked.md
+++ b/docs/hedera-stats/total-value-locked.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 5
 title: Total Value Locked
 ---
 

--- a/docs/hedera-stats/transactions-per-second.md
+++ b/docs/hedera-stats/transactions-per-second.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Transactions Per Second
 ---
 


### PR DESCRIPTION
## Summary
- reorder Hedera Stats pages so the sidebar order flows logically

## Testing
- `npm run build` *(fails: docusaurus not found)*
- `npm run serve` *(fails: docusaurus not found)*

------
https://chatgpt.com/codex/tasks/task_b_685856fb3e2c8322bbf8ee1051cdba75