### PR TITLE
Add real EVM address filtering to ECDSA account metrics

### DIFF
--- a/docs/hedera-stats/new-ecdsa-accounts.md
+++ b/docs/hedera-stats/new-ecdsa-accounts.md
@@ -11,7 +11,10 @@ Counts newly created Hedera accounts that use an ECDSA key during the selected p
 To access this Hedera network statistic ([and others](/category/hedera-stats/)) via Hgraph's GraphQL & REST APIs, [get started here](https://www.hgraph.com/hedera).
 :::
 
-Hedera Stat Name: **`new_ecdsa_accounts`**
+Hedera Stat Names:
+
+- **`new_ecdsa_accounts`** - All new ECDSA accounts
+- **`new_ecdsa_accounts_real_evm`** - New ECDSA accounts with real (non-derived) EVM addresses
 
 ## Methodology
 
@@ -26,17 +29,38 @@ To be included in the count, each account must meet **all** of the following req
 - **Entity Type:** The account must have `type = 'ACCOUNT'`.
 - **Key Field:** The `key` field must be present (`key IS NOT NULL`), indicating the account is cryptographically controlled.
 - **Creation Timestamp:** The account must have a valid creation timestamp (`created_timestamp IS NOT NULL`).
-- **ECDSA Key Identification:**  
-  - The account’s `public_key` must begin with either `02` or `03`.  
-  - These hexadecimal prefixes correspond to compressed ECDSA public keys, as specified in common cryptographic standards.  
+- **ECDSA Key Identification:**
+  - The account’s `public_key` must begin with either `02` or `03`.
+  - These hexadecimal prefixes correspond to compressed ECDSA public keys, as specified in common cryptographic standards.
   - Accounts with public keys starting with other values are excluded.
-- **Time Window:**  
-  - Only accounts created within the requested time period are included.  
+- **Time Window:**
+  - Only accounts created within the requested time period are included.
   - This is enforced by ensuring `created_timestamp` falls between the given `start_timestamp` and `end_timestamp` parameters (expressed in nanoseconds since epoch).
 
 #### Extraction Process
 
 All rows in the `entity` table are evaluated against the criteria above. Accounts that match **every** filter are included as "new ECDSA accounts" for subsequent counting and aggregation.
+
+### Identifying New ECDSA Accounts with Real EVM Addresses
+
+The **`new_ecdsa_accounts_real_evm`** metric provides additional filtering to count only ECDSA accounts that have explicitly set, real EVM addresses (not derived from the Hedera account ID).
+
+#### Additional Filtering for Real EVM Addresses
+
+In addition to all the standard ECDSA account criteria above, this metric applies two additional filters:
+
+- **EVM Address Presence:** The account must have an explicitly set EVM address (`evm_address IS NOT NULL`).
+- **Non-Derived Address Check:** The EVM address must NOT be the default derived address that Hedera automatically generates from the account ID.
+  - Hedera derives a default EVM address using the pattern: 4 bytes shard + 8 bytes realm + 8 bytes num (all zero-padded, big-endian)
+  - The function excludes accounts where the EVM address matches this pattern: `encode(evm_address, 'hex') <> lpad(to_hex(shard), 8, '0') || lpad(to_hex(realm), 16, '0') || lpad(to_hex(num), 16, '0')`
+
+#### Why Filter for Real EVM Addresses?
+
+This distinction is important because:
+
+- **Derived addresses** are automatically generated for every Hedera account and don't necessarily indicate EVM usage intent
+- **Real EVM addresses** are explicitly set and typically indicate accounts that are actively used for EVM/smart contract interactions
+- This metric provides a more accurate count of accounts genuinely participating in the EVM ecosystem on Hedera
 
 ## GraphQL API Examples
 
@@ -72,6 +96,36 @@ query DailyNewECDSAAccounts {
 }
 ```
 
+### Fetch current new ECDSA accounts with real EVM addresses (hourly)
+
+```graphql
+query NewECDSAAccountsRealEVMHour {
+  ecosystem_metric(
+    order_by: {end_date: desc_nulls_last}
+    limit: 1
+    where: {name: {_eq: "new_ecdsa_accounts_real_evm"}, period: {_eq: "hour"}}
+  ) {
+    total
+    end_date
+  }
+}
+```
+
+### Fetch daily new ECDSA accounts with real EVM addresses for 1 month (timeseries)
+
+```graphql
+query DailyNewECDSAAccountsRealEVM {
+  ecosystem_metric(
+    order_by: {end_date: desc_nulls_last}
+    limit: 30
+    where: {name: {_eq: "new_ecdsa_accounts_real_evm"}, period: {_eq: "day"}}
+  ) {
+    total
+    end_date
+  }
+}
+```
+
 ## Available Time Periods
 
 The `period` field supports the following values:
@@ -81,11 +135,15 @@ The `period` field supports the following values:
 
 ## SQL Implementation
 
-Below is a link to the **Hedera Stats** GitHub repository. The repo contains the SQL function that calculates the **New ECDSA Accounts** statistic outlined in this methodology.
+Below is a link to the **Hedera Stats** GitHub repository. The repo contains the SQL functions that calculate the **New ECDSA Accounts** statistics outlined in this methodology.
 
-SQL Function: `ecosystem.dashboard_new_ecdsa_accounts`
+SQL Functions:
+
+- `ecosystem.dashboard_new_ecdsa_accounts` - All new ECDSA accounts
+- `ecosystem.new_ecdsa_accounts_real_evm` - New ECDSA accounts with real (non-derived) EVM addresses
 
 **[View GitHub Repository →](https://github.com/hgraph-io/hedera-stats)**
 
 ## Dependencies
-* Hedera mirror node
+
+- Hedera mirror node

--- a/docs/hedera-stats/total-ecdsa-accounts.md
+++ b/docs/hedera-stats/total-ecdsa-accounts.md
@@ -11,7 +11,9 @@ This statistic shows the cumulative number of Hedera accounts secured with ECDSA
 To access this Hedera network statistic ([and others](/category/hedera-stats/)) via Hgraph's GraphQL & REST APIs, [get started here](https://www.hgraph.com/hedera).
 :::
 
-Hedera Stat Name: **`total_ecdsa_accounts`**
+Hedera Stat Names:
+- **`total_ecdsa_accounts`** - Total of all ECDSA accounts
+- **`total_ecdsa_accounts_real_evm`** - Total ECDSA accounts with real (non-derived) EVM addresses
 
 ## Methodology
 
@@ -24,6 +26,33 @@ To determine the total number of Hedera accounts created with ECDSA cryptographi
 - **ECDSA Key Filter**: The account’s `public_key` field must begin with either `02` or `03` (i.e., `public_key LIKE '02%' OR public_key LIKE '03%'`). These hexadecimal prefixes indicate compressed ECDSA public keys on the Hedera network.
 
 This filtering isolates all account creation events specifically for ECDSA-backed accounts within the requested time window.
+
+### Identifying ECDSA Accounts with Real EVM Addresses
+
+The **`total_ecdsa_accounts_real_evm`** metric provides a rolling total of ECDSA accounts that have explicitly set, real EVM addresses (not derived from the Hedera account ID).
+
+#### Additional Filtering for Real EVM Addresses
+
+In addition to all the standard ECDSA account criteria above, this metric applies two additional filters:
+
+- **EVM Address Presence:** The account must have an explicitly set EVM address (`evm_address IS NOT NULL`).
+- **Non-Derived Address Check:** The EVM address must NOT be the default derived address that Hedera automatically generates from the account ID.
+  - Hedera derives a default EVM address using the pattern: 4 bytes shard + 8 bytes realm + 8 bytes num (all zero-padded, big-endian)
+  - The function excludes accounts where the EVM address matches this pattern: `encode(evm_address, 'hex') <> lpad(to_hex(shard), 8, '0') || lpad(to_hex(realm), 16, '0') || lpad(to_hex(num), 16, '0')`
+
+#### Why Track Real EVM Addresses?
+
+This distinction is important because:
+- **Derived addresses** are automatically generated for every Hedera account and don't necessarily indicate EVM usage intent
+- **Real EVM addresses** are explicitly set and typically indicate accounts that are actively used for EVM/smart contract interactions
+- This metric provides a more accurate count of accounts genuinely participating in the EVM ecosystem on Hedera
+
+#### Rolling Total Calculation
+
+The total is calculated as a cumulative sum:
+1. First, it counts all qualifying accounts created before the requested time window start
+2. Then, it adds new qualifying accounts created within the time window, grouped by the requested period
+3. The result is a running total that increases over time as new ECDSA accounts with real EVM addresses are created
 
 ## GraphQL API Examples
 
@@ -59,6 +88,36 @@ query TotalECDSAAccountsMonthly {
 }
 ```
 
+### Fetch current total ECDSA accounts with real EVM addresses (day)
+
+```graphql
+query TotalECDSAAccountsRealEVMDay {
+  ecosystem_metric(
+    order_by: {end_date: desc_nulls_last}
+    limit: 1
+    where: {name: {_eq: "total_ecdsa_accounts_real_evm"}, period: {_eq: "day"}}
+  ) {
+    total
+    end_date
+  }
+}
+```
+
+### Fetch weekly total ECDSA accounts with real EVM addresses for 3 months (timeseries)
+
+```graphql
+query TotalECDSAAccountsRealEVMWeekly {
+  ecosystem_metric(
+    order_by: {end_date: desc_nulls_last}
+    limit: 12
+    where: {name: {_eq: "total_ecdsa_accounts_real_evm"}, period: {_eq: "week"}}
+  ) {
+    total
+    end_date
+  }
+}
+```
+
 ## Available Time Periods
 
 The `period` field supports the following values:
@@ -71,11 +130,15 @@ The `period` field supports the following values:
 
 ## SQL Implementation
 
-Below is a link to the **Hedera Stats** GitHub repository. The repo contains the SQL function that calculates the **Total ECDSA Accounts** statistic outlined in this methodology.
+Below is a link to the **Hedera Stats** GitHub repository. The repo contains the SQL functions that calculate the **Total ECDSA Accounts** statistics outlined in this methodology.
 
-SQL Function: `ecosystem.dashboard_total_ecdsa_accounts`
+SQL Functions:
+
+- `ecosystem.dashboard_total_ecdsa_accounts` - Total of all ECDSA accounts
+- `ecosystem.total_ecdsa_accounts_real_evm` - Total ECDSA accounts with real (non-derived) EVM addresses
 
 **[View GitHub Repository →](https://github.com/hgraph-io/hedera-stats)**
 
 ## Dependencies
-* Hedera mirror node
+
+- Hedera mirror node


### PR DESCRIPTION
Added total_ecdsa_accounts_real_evm and new_ecdsa_accounts_real_evm metrics that filter for accounts with explicitly set (non-derived) EVM addresses.