### PR TITLE
Add ERC Token Data documentation

### DIFF
--- a/docs/erc-token-data/_category_.json
+++ b/docs/erc-token-data/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "ERC Token Data",
+  "position": 8,
+  "link": {
+    "type": "generated-index",
+    "description": "Access comprehensive ERC token data and analytics on the Hedera network"
+  }
+}

--- a/docs/erc-token-data/_category_.json
+++ b/docs/erc-token-data/_category_.json
@@ -3,6 +3,6 @@
   "position": 8,
   "link": {
     "type": "generated-index",
-    "description": "Access comprehensive ERC token data and analytics on the Hedera network"
+    "description": "Access comprehensive ERC token data and analytics on the Hedera network with Hgraph's GraphQL API."
   }
 }

--- a/docs/erc-token-data/overview.md
+++ b/docs/erc-token-data/overview.md
@@ -5,7 +5,7 @@ title: Introduction
 
 # Hgraph's Hedera ERC Token Data
 
-Hgraph's Hedera ERC Indexer provides comprehensive access to pure ERC-20 and ERC-721 token data on the Hedera network through our GraphQL API. The indexer discovers and tracks tokens deployed directly to Hedera's EVM, analyzes Transfer events, extracts metadata, and calculates token balances for fast queries.
+Hgraph's Hedera ERC Indexer provides comprehensive access to pure **ERC-20** and **ERC-721** token data on the Hedera network through our GraphQL API. The indexer discovers and tracks tokens deployed directly to Hedera's EVM, analyzes Transfer events, extracts metadata, and calculates token balances for fast queries.
 
 :::info In Beta → Hgraph's Hedera ERC Token Data
 

--- a/docs/erc-token-data/overview.md
+++ b/docs/erc-token-data/overview.md
@@ -1,0 +1,96 @@
+---
+sidebar_position: 1
+title: Overview
+---
+
+# Hedera ERC Token Data
+
+Hgraph's Hedera ERC Indexer provides comprehensive access to pure ERC-20 and ERC-721 token data on the Hedera network through our GraphQL API. The indexer discovers and tracks tokens deployed directly to Hedera's EVM, analyzes Transfer events, extracts metadata, and calculates token balances for fast queries.
+
+## Token Types on Hedera
+
+### Key Distinction
+
+The Hedera ERC Indexer focuses on **pure ERC token contracts** deployed directly to
+Hedera's EVM, NOT Hedera Token Service (HTS) tokens with ERC facades.
+
+#### Pure ERC Tokens (What This Indexer Tracks)
+
+- Smart contracts deployed directly to the EVM
+- Generate real Transfer events from contract code
+- NOT in the `public.token` table (only in `public.entity` as CONTRACT)
+- Examples: amWHBAR, amUSDC, Aave-style tokens
+
+#### HTS Tokens with ERC Facades (Excluded)
+
+- Native Hedera Token Service tokens
+- Found in the `public.token` table
+- Use derived "long-zero" addresses
+
+## What's Available
+
+Hgraph's Hedera ERC Indexer continuously tracks pure ERC token contracts deployed to Hedera's EVM and exposes this data via GraphQL API, providing real-time access to:
+
+- ERC-20 token metadata and balances
+- ERC-721 NFT collections and individual NFTs
+- Token holder information
+- Account portfolios across all tokens
+- Historical and statistical data
+
+## Getting Started
+
+### API Access
+
+To access the ERC token data, you'll need:
+1. An Hgraph API key - [See authentication documentation](/hgraph-sdk/endpoints-authorization)
+2. GraphQL endpoint:
+   - Testnet: `https://testnet.hedera.api.hgraph.io/v1/graphql`
+   - Mainnet: `https://mainnet.hedera.api.hgraph.io/v1/graphql`
+
+### Quick Example
+
+```graphql
+query GetERC20Tokens {
+  erc_beta_token(
+    where: { contract_type: { _eq: "ERC_20" } }
+    limit: 10
+  ) {
+    token_id
+    name
+    symbol
+    decimals
+    evm_address
+  }
+}
+```
+
+For more query examples, see our [comprehensive query library](./queries).
+
+## Available Data
+
+The GraphQL API provides access to three main data types:
+
+- **Token Information** (`erc_beta_token`) - Token metadata, contract types, and statistics
+- **Token Balances** (`erc_beta_token_account`) - Account balances and holder information
+- **NFT Details** (`erc_beta_nft`) - Individual NFT ownership and metadata
+
+For detailed schema information, see the [Schema Reference](./schema-reference).
+
+## Understanding Token Types on Hedera
+
+Hedera has two types of ERC-compatible tokens:
+
+1. **Pure ERC Tokens** - Standard smart contracts deployed directly to the EVM (tracked by this indexer)
+2. **HTS Tokens with ERC Facades** - Native Hedera Token Service tokens (not included in this data)
+
+For a detailed explanation of the differences, see [Token Types](./token-types).
+
+
+
+## Additional Resources
+
+- **[Schema Reference](./schema-reference)** - Detailed field descriptions and data types
+- **[Token Types](./token-types)** - Understanding pure ERC vs HTS tokens
+- **[Technical Details](./technical-details)** - Event signatures, account identifiers, and reliability scoring
+- **[Query Examples](./queries)** - Comprehensive GraphQL query library
+- **[Authentication](/hgraph-sdk/endpoints-authorization)** - API key setup and usage

--- a/docs/erc-token-data/overview.md
+++ b/docs/erc-token-data/overview.md
@@ -1,11 +1,17 @@
 ---
 sidebar_position: 1
-title: Overview
+title: Introduction
 ---
 
-# Hedera ERC Token Data
+# Hgraph's Hedera ERC Token Data
 
 Hgraph's Hedera ERC Indexer provides comprehensive access to pure ERC-20 and ERC-721 token data on the Hedera network through our GraphQL API. The indexer discovers and tracks tokens deployed directly to Hedera's EVM, analyzes Transfer events, extracts metadata, and calculates token balances for fast queries.
+
+:::info In Beta → Hgraph's Hedera ERC Token Data
+
+This new data service is currently in beta and we encourage all users to provide feedback. Please [contact us to share your input](../overview/contact.md).
+
+:::
 
 ## Token Types on Hedera
 
@@ -42,6 +48,7 @@ Hgraph's Hedera ERC Indexer continuously tracks pure ERC token contracts deploye
 ### API Access
 
 To access the ERC token data, you'll need:
+
 1. An Hgraph API key - [See authentication documentation](/hgraph-sdk/endpoints-authorization)
 2. GraphQL endpoint:
    - Testnet: `https://testnet.hedera.api.hgraph.io/v1/graphql`
@@ -52,16 +59,23 @@ To access the ERC token data, you'll need:
 ```graphql
 query GetERC20Tokens {
   erc_beta_token(
-    where: { contract_type: { _eq: "ERC_20" } }
+    where: {contract_type: {_eq: "ERC_20"}}
     limit: 10
+    order_by: {transfer_count: desc_nulls_last}
   ) {
     token_id
     name
     symbol
     decimals
     evm_address
+    metadata_reliability_score
+    processing_timestamp
+    total_supply
+    transfer_count
+    created_timestamp
+    contract_type
   }
-}
+}}
 ```
 
 For more query examples, see our [comprehensive query library](./queries).
@@ -76,7 +90,7 @@ The GraphQL API provides access to three main data types:
 
 For detailed schema information, see the [Schema Reference](./schema-reference).
 
-## Understanding Token Types on Hedera
+## ERC vs HTS (Understanding Token Types)
 
 Hedera has two types of ERC-compatible tokens:
 
@@ -84,8 +98,6 @@ Hedera has two types of ERC-compatible tokens:
 2. **HTS Tokens with ERC Facades** - Native Hedera Token Service tokens (not included in this data)
 
 For a detailed explanation of the differences, see [Token Types](./token-types).
-
-
 
 ## Additional Resources
 

--- a/docs/erc-token-data/queries.md
+++ b/docs/erc-token-data/queries.md
@@ -1,0 +1,580 @@
+---
+sidebar_position: 2
+---
+
+# Query Examples
+
+This page provides a comprehensive collection of GraphQL queries for accessing ERC token data.
+
+## Prerequisites
+
+### API Endpoints
+
+- **Testnet**: `https://testnet.hedera.api.hgraph.io/v1/graphql`
+- **Mainnet**: `https://mainnet.hedera.api.hgraph.io/v1/graphql`
+
+### Authentication
+
+All queries require an API key. See the [authentication documentation](/hgraph-sdk/endpoints-authorization) for setup instructions.
+
+### Example Request
+
+```javascript
+const response = await fetch('https://testnet.hedera.api.hgraph.io/v1/graphql', {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'x-api-key': '<YOUR_API_KEY>',
+  },
+  body: JSON.stringify({
+    query: `your GraphQL query here`
+  })
+})
+```
+
+## Basic Queries
+
+### 1. Get All ERC-20 Tokens
+
+```graphql
+query GetERC20Tokens {
+  erc_beta_token(
+    where: { contract_type: { _eq: "ERC_20" } }
+    order_by: { transfer_count: desc }
+    limit: 10
+  ) {
+    token_id
+    name
+    symbol
+    decimals
+    total_supply
+    evm_address
+    transfer_count
+    created_timestamp
+    metadata_reliability_score
+  }
+}
+```
+
+### 2. Get All ERC-721 NFT Collections
+
+```graphql
+query GetNFTCollections {
+  erc_beta_token(
+    where: { contract_type: { _eq: "ERC_721" } }
+    order_by: { transfer_count: desc }
+    limit: 10
+  ) {
+    token_id
+    name
+    symbol
+    evm_address
+    transfer_count
+    created_timestamp
+    metadata_reliability_score
+  }
+}
+```
+
+### 3. Search Tokens by Name or Symbol
+
+```graphql
+query SearchTokens($searchTerm: String!) {
+  erc_beta_token(
+    where: {
+      _or: [
+        { name: { _ilike: $searchTerm } }
+        { symbol: { _ilike: $searchTerm } }
+      ]
+    }
+  ) {
+    token_id
+    name
+    symbol
+    contract_type
+    decimals
+    evm_address
+    metadata_reliability_score
+  }
+}
+
+# Variables:
+# { "searchTerm": "%USDC%" }
+```
+
+### 4. Get Token Holders
+
+```graphql
+query GetTokenHolders($tokenId: bigint!) {
+  erc_beta_token_account(
+    where: { token_id: { _eq: $tokenId } }
+    order_by: { balance: desc }
+    limit: 20
+  ) {
+    account_id
+    balance
+    balance_timestamp
+    created_timestamp
+  }
+}
+
+# Variables:
+# { "tokenId": 7308509 }
+```
+
+### 5. Get Account Portfolio
+
+```graphql
+query GetAccountPortfolio($accountId: bigint!) {
+  erc_beta_token_account(
+    where: { account_id: { _eq: $accountId } }
+    order_by: { balance: desc }
+  ) {
+    token_id
+    balance
+    balance_timestamp
+    created_timestamp
+  }
+}
+
+# Variables:
+# { "accountId": 924713 }
+# 
+# Note: To get token details, make a separate query with the token_ids from above:
+# query GetTokenDetails($tokenIds: [bigint!]) {
+#   erc_beta_token(where: { token_id: { _in: $tokenIds } }) {
+#     token_id
+#     name
+#     symbol
+#     contract_type
+#     decimals
+#     evm_address
+#   }
+# }
+```
+
+## Advanced Queries
+
+### 6. Get Individual NFTs in a Collection
+
+```graphql
+query GetNFTsInCollection($tokenId: bigint!, $limit: Int = 50, $offset: Int = 0) {
+  erc_beta_nft(
+    where: { 
+      token_id: { _eq: $tokenId }
+      deleted: { _eq: false }
+    }
+    limit: $limit
+    offset: $offset
+    order_by: { serial_number: asc }
+  ) {
+    serial_number
+    account_id
+    metadata
+    created_timestamp
+  }
+  
+  # Get total count for pagination
+  erc_beta_nft_aggregate(
+    where: { 
+      token_id: { _eq: $tokenId }
+      deleted: { _eq: false }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+}
+
+# Variables:
+# { "tokenId": 7308509, "limit": 50, "offset": 0 }
+```
+
+### 7. Get NFTs Owned by an Account
+
+```graphql
+query GetAccountNFTs($accountId: bigint!) {
+  # Get individual NFTs
+  nfts: erc_beta_nft(
+    where: { 
+      account_id: { _eq: $accountId }
+      deleted: { _eq: false }
+    }
+    order_by: { token_id: asc, serial_number: asc }
+  ) {
+    token_id
+    serial_number
+    metadata
+    created_timestamp
+  }
+  
+  # Get total count of NFTs owned
+  nft_count: erc_beta_nft_aggregate(
+    where: { 
+      account_id: { _eq: $accountId }
+      deleted: { _eq: false }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+}
+
+# Variables:
+# { "accountId": 924713 }
+```
+
+### 8. Platform Statistics
+
+```graphql
+query PlatformStatistics {
+  erc20_count: erc_beta_token_aggregate(where: {contract_type: {_eq: "ERC_20"}}) {
+    aggregate {
+      count
+    }
+  }
+  erc721_count: erc_beta_token_aggregate(where: {contract_type: {_eq: "ERC_721"}}) {
+    aggregate {
+      count
+    }
+  }
+  most_active: erc_beta_token(
+    where: {contract_type: {_in: ["ERC_20", "ERC_721"]}}
+    order_by: {transfer_count: desc_nulls_last}
+    limit: 5
+  ) {
+    token_id
+    name
+    symbol
+    contract_type
+    transfer_count
+    evm_address
+  }
+  newest_tokens: erc_beta_token(
+    where: {contract_type: {_in: ["ERC_20", "ERC_721"]}}
+    order_by: {created_timestamp: desc_nulls_last}
+    limit: 5
+  ) {
+    token_id
+    name
+    symbol
+    contract_type
+    created_timestamp
+    evm_address
+  }
+  total_holders: erc_beta_token_account_aggregate {
+    aggregate {
+      count(distinct: true, columns: account_id)
+    }
+  }
+}
+```
+
+### 9. High-Quality Tokens Only
+
+```graphql
+query ReliableTokens($minScore: numeric = 0.75) {
+  erc_beta_token(
+    where: { 
+      metadata_reliability_score: { _gte: $minScore }
+      contract_type: { _in: ["ERC_20", "ERC_721"] }
+    }
+    order_by: { 
+      metadata_reliability_score: desc,
+      transfer_count: desc 
+    }
+  ) {
+    token_id
+    name
+    symbol
+    contract_type
+    metadata_reliability_score
+    evm_address
+    transfer_count
+  }
+}
+
+# Variables:
+# { "minScore": 0.5 }
+```
+
+### 10. Token Deep Dive
+
+```graphql
+query TokenDeepDive($tokenId: bigint!) {
+  # Token details
+  token: erc_beta_token_by_pk(token_id: $tokenId) {
+    token_id
+    evm_address
+    contract_type
+    name
+    symbol
+    decimals
+    total_supply
+    metadata_reliability_score
+    created_timestamp
+    transfer_count
+    processing_timestamp
+  }
+  
+  # Holder statistics
+  holder_stats: erc_beta_token_account_aggregate(
+    where: { token_id: { _eq: $tokenId } }
+  ) {
+    aggregate {
+      count
+      sum {
+        balance
+      }
+      avg {
+        balance
+      }
+      max {
+        balance
+      }
+    }
+  }
+  
+  # Top 10 holders
+  top_holders: erc_beta_token_account(
+    where: { token_id: { _eq: $tokenId } }
+    order_by: { balance: desc }
+    limit: 10
+  ) {
+    account_id
+    balance
+    balance_timestamp
+  }
+  
+  # Recent holders
+  recent_holders: erc_beta_token_account(
+    where: { token_id: { _eq: $tokenId } }
+    order_by: { created_timestamp: desc }
+    limit: 5
+  ) {
+    account_id
+    balance
+    created_timestamp
+  }
+}
+
+# Variables:
+# { "tokenId": 7308509 }
+```
+
+## Real-World Use Cases
+
+### DeFi Portfolio Tracker
+
+Track all DeFi positions for an account:
+
+```graphql
+query DeFiPortfolio($accountId: bigint!) {
+  # ERC-20 holdings with balances
+  erc20_holdings: erc_beta_token_account(
+    where: { 
+      account_id: { _eq: $accountId }
+      balance: { _gt: "0" }
+    }
+  ) {
+    token_id
+    balance
+    balance_timestamp
+  }
+  
+  # Portfolio summary
+  portfolio_summary: erc_beta_token_account_aggregate(
+    where: { 
+      account_id: { _eq: $accountId }
+      balance: { _gt: "0" }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+}
+
+# Variables:
+# { "accountId": 924713 }
+```
+
+### NFT Collection Analytics
+
+Analyze an NFT collection's distribution:
+
+```graphql
+query NFTCollectionAnalytics($tokenId: bigint!) {
+  collection: erc_beta_token_by_pk(token_id: $tokenId) {
+    name
+    symbol
+    total_supply
+    transfer_count
+  }
+  
+  # Holder distribution
+  holder_distribution: erc_beta_token_account_aggregate(
+    where: { token_id: { _eq: $tokenId } }
+  ) {
+    aggregate {
+      count  # unique holders
+      avg {
+        balance  # average NFTs per holder
+      }
+      max {
+        balance  # largest holder
+      }
+    }
+  }
+  
+  # Top collectors
+  top_collectors: erc_beta_token_account(
+    where: { token_id: { _eq: $tokenId } }
+    order_by: { balance: desc }
+    limit: 10
+  ) {
+    account_id
+    balance
+  }
+  
+  # Total NFTs (minted minus burned)
+  total_nfts: erc_beta_nft_aggregate(
+    where: { 
+      token_id: { _eq: $tokenId }
+      deleted: { _eq: false }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+  
+  # Burned NFTs count
+  burned_nfts: erc_beta_nft_aggregate(
+    where: { 
+      token_id: { _eq: $tokenId }
+      deleted: { _eq: true }
+    }
+  ) {
+    aggregate {
+      count
+    }
+  }
+}
+
+# Variables:
+# { "tokenId": 9799174 }
+```
+
+### Token Discovery
+
+Find new tokens launched in the last 24 hours:
+
+```graphql
+query NewTokens($hoursAgo: Int = 24) {
+  erc_beta_token(
+    where: {
+      # Calculate timestamp for N hours ago
+      # Assuming current time - (hours * 3600 * 1e9) nanoseconds
+      created_timestamp: { _gte: "1234567890000000000" }
+      contract_type: { _in: ["ERC_20", "ERC_721"] }
+    }
+    order_by: { created_timestamp: desc }
+  ) {
+    token_id
+    name
+    symbol
+    contract_type
+    evm_address
+    created_timestamp
+    transfer_count
+    metadata_reliability_score
+  }
+}
+```
+
+### Whale Wallet Monitoring
+
+Monitor large holders across multiple tokens:
+
+```graphql
+query WhaleActivity($minBalance: numeric = "1000000000000000000") {
+  # Find whale positions
+  whale_positions: erc_beta_token_account(
+    where: {
+      balance: { _gte: $minBalance }
+    }
+    order_by: { balance: desc }
+    limit: 50
+  ) {
+    account_id
+    token_id
+    balance
+    balance_timestamp
+  }
+  
+  # Aggregate whale statistics
+  whale_stats: erc_beta_token_account_aggregate(
+    where: {
+      balance: { _gte: $minBalance }
+    }
+  ) {
+    aggregate {
+      count
+      sum {
+        balance
+      }
+    }
+  }
+}
+```
+
+### Cross-Token Account Analysis
+
+Analyze an account's activity across all tokens:
+
+```graphql
+query AccountCrossTokenAnalysis($accountId: bigint!) {
+  # Get all token balances for the account
+  account_tokens: erc_beta_token_account(
+    where: { account_id: { _eq: $accountId } }
+  ) {
+    token_id
+    balance
+    created_timestamp
+  }
+  
+  # First and latest activities
+  activity_timeline: erc_beta_token_account_aggregate(
+    where: { account_id: { _eq: $accountId } }
+  ) {
+    aggregate {
+      min {
+        created_timestamp
+      }
+      max {
+        balance_timestamp
+      }
+    }
+  }
+  
+  # Activity timeline
+  activity_timeline: erc_beta_token_account_aggregate(
+    where: { account_id: { _eq: $accountId } }
+  ) {
+    aggregate {
+      min {
+        created_timestamp
+      }
+      max {
+        balance_timestamp
+      }
+    }
+  }
+}
+
+# Variables:
+# { "accountId": 924713 }
+```

--- a/docs/erc-token-data/queries.md
+++ b/docs/erc-token-data/queries.md
@@ -1,10 +1,17 @@
 ---
 sidebar_position: 2
+title: Query Examples
 ---
 
 # Query Examples
 
 This page provides a comprehensive collection of GraphQL queries for accessing ERC token data.
+
+:::info In Beta → Hgraph's Hedera ERC Token Data
+
+This new data service is currently in beta and we encourage all users to provide feedback. Please [contact us to share your input](../overview/contact.md).
+
+:::
 
 ## Prerequisites
 
@@ -139,7 +146,7 @@ query GetAccountPortfolio($accountId: bigint!) {
 
 # Variables:
 # { "accountId": 924713 }
-# 
+#
 # Note: To get token details, make a separate query with the token_ids from above:
 # query GetTokenDetails($tokenIds: [bigint!]) {
 #   erc_beta_token(where: { token_id: { _in: $tokenIds } }) {
@@ -160,7 +167,7 @@ query GetAccountPortfolio($accountId: bigint!) {
 ```graphql
 query GetNFTsInCollection($tokenId: bigint!, $limit: Int = 50, $offset: Int = 0) {
   erc_beta_nft(
-    where: { 
+    where: {
       token_id: { _eq: $tokenId }
       deleted: { _eq: false }
     }
@@ -173,10 +180,10 @@ query GetNFTsInCollection($tokenId: bigint!, $limit: Int = 50, $offset: Int = 0)
     metadata
     created_timestamp
   }
-  
+
   # Get total count for pagination
   erc_beta_nft_aggregate(
-    where: { 
+    where: {
       token_id: { _eq: $tokenId }
       deleted: { _eq: false }
     }
@@ -197,7 +204,7 @@ query GetNFTsInCollection($tokenId: bigint!, $limit: Int = 50, $offset: Int = 0)
 query GetAccountNFTs($accountId: bigint!) {
   # Get individual NFTs
   nfts: erc_beta_nft(
-    where: { 
+    where: {
       account_id: { _eq: $accountId }
       deleted: { _eq: false }
     }
@@ -208,10 +215,10 @@ query GetAccountNFTs($accountId: bigint!) {
     metadata
     created_timestamp
   }
-  
+
   # Get total count of NFTs owned
   nft_count: erc_beta_nft_aggregate(
-    where: { 
+    where: {
       account_id: { _eq: $accountId }
       deleted: { _eq: false }
     }
@@ -277,13 +284,13 @@ query PlatformStatistics {
 ```graphql
 query ReliableTokens($minScore: numeric = 0.75) {
   erc_beta_token(
-    where: { 
+    where: {
       metadata_reliability_score: { _gte: $minScore }
       contract_type: { _in: ["ERC_20", "ERC_721"] }
     }
-    order_by: { 
+    order_by: {
       metadata_reliability_score: desc,
-      transfer_count: desc 
+      transfer_count: desc
     }
   ) {
     token_id
@@ -318,7 +325,7 @@ query TokenDeepDive($tokenId: bigint!) {
     transfer_count
     processing_timestamp
   }
-  
+
   # Holder statistics
   holder_stats: erc_beta_token_account_aggregate(
     where: { token_id: { _eq: $tokenId } }
@@ -336,7 +343,7 @@ query TokenDeepDive($tokenId: bigint!) {
       }
     }
   }
-  
+
   # Top 10 holders
   top_holders: erc_beta_token_account(
     where: { token_id: { _eq: $tokenId } }
@@ -347,7 +354,7 @@ query TokenDeepDive($tokenId: bigint!) {
     balance
     balance_timestamp
   }
-  
+
   # Recent holders
   recent_holders: erc_beta_token_account(
     where: { token_id: { _eq: $tokenId } }
@@ -374,7 +381,7 @@ Track all DeFi positions for an account:
 query DeFiPortfolio($accountId: bigint!) {
   # ERC-20 holdings with balances
   erc20_holdings: erc_beta_token_account(
-    where: { 
+    where: {
       account_id: { _eq: $accountId }
       balance: { _gt: "0" }
     }
@@ -383,10 +390,10 @@ query DeFiPortfolio($accountId: bigint!) {
     balance
     balance_timestamp
   }
-  
+
   # Portfolio summary
   portfolio_summary: erc_beta_token_account_aggregate(
-    where: { 
+    where: {
       account_id: { _eq: $accountId }
       balance: { _gt: "0" }
     }
@@ -413,7 +420,7 @@ query NFTCollectionAnalytics($tokenId: bigint!) {
     total_supply
     transfer_count
   }
-  
+
   # Holder distribution
   holder_distribution: erc_beta_token_account_aggregate(
     where: { token_id: { _eq: $tokenId } }
@@ -428,7 +435,7 @@ query NFTCollectionAnalytics($tokenId: bigint!) {
       }
     }
   }
-  
+
   # Top collectors
   top_collectors: erc_beta_token_account(
     where: { token_id: { _eq: $tokenId } }
@@ -438,10 +445,10 @@ query NFTCollectionAnalytics($tokenId: bigint!) {
     account_id
     balance
   }
-  
+
   # Total NFTs (minted minus burned)
   total_nfts: erc_beta_nft_aggregate(
-    where: { 
+    where: {
       token_id: { _eq: $tokenId }
       deleted: { _eq: false }
     }
@@ -450,10 +457,10 @@ query NFTCollectionAnalytics($tokenId: bigint!) {
       count
     }
   }
-  
+
   # Burned NFTs count
   burned_nfts: erc_beta_nft_aggregate(
-    where: { 
+    where: {
       token_id: { _eq: $tokenId }
       deleted: { _eq: true }
     }
@@ -514,7 +521,7 @@ query WhaleActivity($minBalance: numeric = "1000000000000000000") {
     balance
     balance_timestamp
   }
-  
+
   # Aggregate whale statistics
   whale_stats: erc_beta_token_account_aggregate(
     where: {
@@ -545,7 +552,7 @@ query AccountCrossTokenAnalysis($accountId: bigint!) {
     balance
     created_timestamp
   }
-  
+
   # First and latest activities
   activity_timeline: erc_beta_token_account_aggregate(
     where: { account_id: { _eq: $accountId } }
@@ -559,7 +566,7 @@ query AccountCrossTokenAnalysis($accountId: bigint!) {
       }
     }
   }
-  
+
   # Activity timeline
   activity_timeline: erc_beta_token_account_aggregate(
     where: { account_id: { _eq: $accountId } }

--- a/docs/erc-token-data/schema-reference.md
+++ b/docs/erc-token-data/schema-reference.md
@@ -13,58 +13,6 @@ This new data service is currently in beta and we encourage all users to provide
 
 :::
 
-## Entity Relationship Diagram
-
-### ERD Mermaid Chart
-
-```mermaid
-erDiagram
-    TOKEN {
-        bigint token_id PK "Hedera contract ID"
-        string evm_address UK "Contract EVM address"
-        string contract_type "ERC_20 or ERC_721"
-        string name "Token name (RPC)"
-        string symbol "Token symbol"
-        bigint decimals "ERC-20 decimals"
-        decimal total_supply "Total supply"
-        decimal reliability_score "Quality (0 to 1)"
-        timestamp created_timestamp "Creation time"
-        bigint transfer_count "Transfer events"
-        timestamp processing_timestamp "Last updated"
-    }
-
-    TOKEN_ACCOUNT {
-        bigint account_id PK "Hedera account ID (resolved)"
-        bigint token_id PK, FK "References token"
-        decimal balance "Amount or count"
-        timestamp balance_timestamp "Last update"
-        timestamp created_timestamp "First seen"
-        boolean associated "Always true"
-    }
-
-    NFT {
-        bigint token_id PK, FK "References token"
-        numeric serial_number PK "NFT tokenId (uint256)"
-        bigint account_id "Current owner"
-        boolean deleted "Burn status"
-        bytes metadata "URI or JSON"
-        timestamp created_timestamp "Mint time"
-        timestamp processing_timestamp "Processing time"
-    }
-
-    TOKEN ||--o{ TOKEN_ACCOUNT : "ERC token has balances"
-    TOKEN ||--o{ NFT : "ERC token contains NFTs"
-```
-
-### Notation Guide
-
-- **PK** = Primary Key (unique identifier for each record)
-- **FK** = Foreign Key (references another table's primary key)
-- **UK** = Unique Key (indexed field for fast lookups)
-- **PK, FK** = Field serving as both primary key and foreign key (composite
-  keys)
-- **||--o{** = One-to-many relationship (one TOKEN can have many TOKEN_ACCOUNTs)
-
 ## erc_beta_token
 
 Stores metadata for pure ERC-20 and ERC-721 token contracts deployed to Hedera's EVM.

--- a/docs/erc-token-data/schema-reference.md
+++ b/docs/erc-token-data/schema-reference.md
@@ -1,0 +1,184 @@
+---
+sidebar_position: 3
+---
+
+# Schema Reference
+
+The GraphQL API provides access to ERC token data through three main tables. This page details the available fields, data types, and relationships.
+
+## erc_beta_token
+
+Stores metadata for pure ERC-20 and ERC-721 token contracts deployed to Hedera's EVM.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token_id` | bigint | Hedera entity ID for the contract |
+| `evm_address` | string | Contract's EVM address (0x format) |
+| `contract_type` | string | Token type: `ERC_20`, `ERC_721`, `UNKNOWN`, or `FAILED_DEPLOYMENT` |
+| `name` | string | Token name |
+| `symbol` | string | Token symbol |
+| `decimals` | bigint | Decimal places (ERC-20 only, NULL for ERC-721) |
+| `total_supply` | numeric | Total token supply (handles uint256 values) |
+| `metadata_reliability_score` | decimal | Quality score from 0.00 to 1.00 |
+| `created_timestamp` | bigint | Contract creation time (nanoseconds since epoch) |
+| `transfer_count` | bigint | Total number of Transfer events |
+| `processing_timestamp` | bigint | Last processing time (seconds since epoch) |
+
+### Token Features
+
+- Primary storage for token contract metadata
+- Distinguishes between ERC-20 and ERC-721 standards
+- Tracks deployment failures and unknown contract types
+- Includes reliability scoring for metadata quality
+
+## erc_beta_token_account
+
+Tracks ERC-20 balances and ERC-721 ownership counts with unified account tracking.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `account_id` | bigint | Hedera account ID (resolved from EVM addresses) |
+| `token_id` | bigint | References erc_beta_token |
+| `balance` | numeric | Token balance (wei for ERC-20, NFT count for ERC-721) |
+| `balance_timestamp` | bigint | Last balance update (nanoseconds since epoch) |
+| `created_timestamp` | bigint | First association time (nanoseconds since epoch) |
+| `associated` | boolean | Always true for pure ERC tokens |
+
+### Account Features
+
+- All addresses resolved to Hedera account IDs (no fragmentation)
+- EVM addresses automatically resolved via account-num aliases or entity lookups
+- Stores balances as NUMERIC to handle uint256 values
+- For ERC-20: Balance in wei (smallest unit)
+- For ERC-721: Count of NFTs owned by account
+- Primary key: (token_id, account_id) ensures one balance per account-token pair
+
+## erc_beta_nft
+
+Tracks individual NFTs within ERC-721 collections.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token_id` | bigint | References the ERC-721 contract in erc_beta_token |
+| `serial_number` | numeric | The individual NFT's tokenId (supports full uint256 range) |
+| `account_id` | bigint | Current owner's Hedera account ID (NULL for unresolved addresses) |
+| `deleted` | boolean | Burn status (true if NFT was burned) |
+| `metadata` | bytea | Metadata URI (e.g., ipfs://... or https://...) |
+| `created_timestamp` | bigint | When NFT was first minted (nanoseconds since epoch) |
+| `processing_timestamp` | bigint | When this record was processed (seconds since epoch) |
+
+### NFT Features
+
+- Individual NFT ownership tracking by tokenId
+- Automatic tokenURI metadata extraction for all NFTs
+- Burn status tracking via deleted flag
+- Supports full uint256 range for tokenIds
+
+## Data Types and Constraints
+
+### Numeric Types
+
+- **BIGINT**: Used for Hedera IDs, timestamps, and counts
+- **NUMERIC**: Used for balances and supplies (handles uint256 values up to 2^256-1)
+- **DECIMAL(3,2)**: Used for reliability scores (0.00 to 1.00)
+
+### Timestamp Formats
+
+- **created_timestamp**: Nanoseconds since epoch (Hedera format)
+- **balance_timestamp**: Nanoseconds since epoch (Hedera format)
+- **processing_timestamp**: Seconds since epoch (standard Unix time)
+
+### Contract Types
+
+Valid values for `contract_type` field:
+
+- `ERC_20`: Standard ERC-20 fungible token
+- `ERC_721`: Standard ERC-721 NFT collection
+- `UNKNOWN`: Contract type could not be determined
+- `FAILED_DEPLOYMENT`: Contract deployment failed
+
+## Metadata Reliability Score
+
+The `metadata_reliability_score` field indicates the quality of extracted metadata:
+
+### ERC-20 Tokens (4 fields)
+
+Scoring based on: name, symbol, decimals, totalSupply
+
+- **1.00**: All 4 fields extracted successfully
+- **0.75**: 3 of 4 fields extracted
+- **0.50**: 2 of 4 fields extracted
+- **0.25**: 1 of 4 fields extracted
+- **0.00**: No metadata extracted
+
+### ERC-721 NFTs (3 fields)
+
+Scoring based on: name, symbol, totalSupply
+
+- **1.00**: All 3 fields extracted successfully
+- **0.67**: 2 of 3 fields extracted
+- **0.33**: 1 of 3 fields extracted
+- **0.00**: No metadata extracted
+
+### Unknown/Failed Deployments
+
+- **1.00**: Both name and symbol extracted
+- **0.50**: Either name OR symbol extracted
+- **0.00**: No metadata extracted
+
+## Relationships
+
+The tables are related as follows:
+
+```text
+erc_beta_token (1) ─────────────┬──── (*) erc_beta_token_account
+                                │
+                                └──── (*) erc_beta_nft
+```
+
+- One token can have many account balances
+- One token can have many NFTs (for ERC-721 tokens)
+- Account balances reference tokens via `token_id`
+- NFTs reference their collection via `token_id`
+
+## Query Examples
+
+### Get token with its holders
+
+```graphql
+query TokenWithHolders($tokenId: bigint!) {
+  erc_beta_token_by_pk(token_id: $tokenId) {
+    name
+    symbol
+    contract_type
+    token_accounts {
+      account_id
+      balance
+    }
+  }
+}
+```
+
+### Get NFT collection with individual NFTs
+
+```graphql
+query NFTCollection($tokenId: bigint!) {
+  erc_beta_token_by_pk(token_id: $tokenId) {
+    name
+    symbol
+    nfts(where: { deleted: { _eq: false } }) {
+      serial_number
+      account_id
+      metadata
+    }
+  }
+}
+```
+
+For more comprehensive query examples, see the [Query Examples](./queries) page.

--- a/docs/erc-token-data/technical-details.md
+++ b/docs/erc-token-data/technical-details.md
@@ -75,7 +75,7 @@ event Transfer(address indexed from, address indexed to, uint256 value_or_tokenI
 
 **Event Signature Hash:**
 
-```
+```text
 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
 ```
 
@@ -89,7 +89,7 @@ event Approval(address indexed owner, address indexed spender, uint256 value)
 
 **Event Signature Hash:**
 
-```
+```text
 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925
 ```
 

--- a/docs/erc-token-data/technical-details.md
+++ b/docs/erc-token-data/technical-details.md
@@ -1,0 +1,276 @@
+---
+sidebar_position: 5
+---
+
+# Technical Details
+
+This page covers technical specifications for working with ERC token data on Hedera, including account identifiers, event signatures, and data formats.
+
+## Account Identifiers and Aliases
+
+### Understanding Hedera Account Systems
+
+Every entity on Hedera has a unique account ID (e.g., 0.0.12345), but accounts can be referenced through multiple identifiers:
+
+#### 1. Account Number (Native Hedera Format)
+
+- **Format**: `<shard>.<realm>.<account_number>` (e.g., 0.0.924713)
+- **Usage**: Native Hedera transactions and queries
+- **In Topics**: Stored as 1-8 bytes depending on size
+
+#### 2. Account-num Alias (Long-zero Address)
+
+- **Format**: 20-byte EVM address with 12 leading zeros
+- **Example**: `0x00000000000000000000000000000e1c29` (Account 924713)
+- **Purpose**: Makes every Hedera account EVM-compatible
+- **Resolution**: Direct calculation from bytes (no lookup needed)
+
+#### 3. ECDSA EVM Alias
+
+- **Format**: Standard 20-byte Ethereum address
+- **Example**: `0x6d9f1a927cbcb5e2c28d13ca735bc6d6131406da`
+- **Purpose**: Allows MetaMask and EVM wallets to interact with Hedera
+- **Resolution**: Requires lookup to map to Hedera account ID
+
+### Hollow Accounts and Auto-Creation
+
+When an EVM address receives tokens or HBAR before having a Hedera account:
+
+1. **Hollow Account Creation**: System automatically creates an incomplete account
+2. **Properties**: Has account ID and alias, but no key (can receive but not send)
+3. **Completion**: Becomes full account when used as fee payer with proper signature
+4. **Important**: Every hollow account still has a unique Hedera ID
+
+## Event Detection & Signatures
+
+### Transfer Event
+
+All ERC-20 and ERC-721 tokens emit a standardized `Transfer` event:
+
+```solidity
+event Transfer(address indexed from, address indexed to, uint256 value_or_tokenId)
+```
+
+**Event Signature Hash:**
+```
+0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
+```
+
+This signature is the keccak256 hash of the event declaration and is always the same for all ERC Transfer events.
+
+### Approval Event
+
+```solidity
+event Approval(address indexed owner, address indexed spender, uint256 value)
+```
+
+**Event Signature Hash:**
+```
+0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925
+```
+
+### Token Type Detection
+
+The indexer distinguishes token types by analyzing event structure:
+
+#### ERC-20 Detection
+- **Characteristic**: `topic3 IS NULL` 
+- **Reason**: Transfer value is stored in the event's data section
+- **Structure**: Transfer(from, to, amount) - amount goes in data section
+
+#### ERC-721 Detection
+- **Characteristic**: `topic3 IS NOT NULL`
+- **Reason**: Unique tokenId is indexed and gets its own topic slot
+- **Structure**: Transfer(from, to, tokenId) - tokenId becomes topic3
+
+## Standard ERC Methods
+
+Both ERC-20 and ERC-721 tokens implement standard methods that the indexer queries:
+
+### Common Methods (Both Standards)
+
+```solidity
+function name() external view returns (string memory);
+function symbol() external view returns (string memory);
+```
+
+### ERC-20 Specific Methods
+
+```solidity
+function decimals() external view returns (uint8);
+function totalSupply() external view returns (uint256);
+function balanceOf(address account) external view returns (uint256);
+```
+
+### ERC-721 Specific Methods
+
+```solidity
+function totalSupply() external view returns (uint256);  // Optional
+function ownerOf(uint256 tokenId) external view returns (address);
+function tokenURI(uint256 tokenId) external view returns (string memory);
+```
+
+## Reliability Scoring
+
+The indexer calculates quality scores based on metadata completeness to help identify well-formed contracts.
+
+### Scoring Methodology
+
+The `metadata_reliability_score` field indicates how many standard methods returned valid data:
+
+#### ERC-20 Tokens (4 fields)
+
+Fields checked: `name`, `symbol`, `decimals`, `totalSupply`
+
+| Score | Fields Extracted | Meaning |
+|-------|-----------------|---------|
+| 1.00 | 4 of 4 | Fully compliant ERC-20 |
+| 0.75 | 3 of 4 | Mostly compliant |
+| 0.50 | 2 of 4 | Partial implementation |
+| 0.25 | 1 of 4 | Minimal implementation |
+| 0.00 | 0 of 4 | No metadata available |
+
+#### ERC-721 NFTs (3 fields)
+
+Fields checked: `name`, `symbol`, `totalSupply` (decimals not applicable)
+
+| Score | Fields Extracted | Meaning |
+|-------|-----------------|---------|
+| 1.00 | 3 of 3 | Fully compliant ERC-721 |
+| 0.67 | 2 of 3 | Mostly compliant |
+| 0.33 | 1 of 3 | Minimal implementation |
+| 0.00 | 0 of 3 | No metadata available |
+
+#### Unknown/Failed Deployments
+
+For contracts that couldn't be identified as ERC-20 or ERC-721:
+
+| Score | Fields Extracted | Meaning |
+|-------|-----------------|---------|
+| 1.00 | name AND symbol | Basic token interface |
+| 0.50 | name OR symbol | Partial interface |
+| 0.00 | Neither | No standard interface |
+
+### Using Reliability Scores
+
+Filter for high-quality tokens in your queries:
+
+```graphql
+query ReliableTokens {
+  erc_beta_token(
+    where: { 
+      metadata_reliability_score: { _gte: 0.75 }
+      contract_type: { _in: ["ERC_20", "ERC_721"] }
+    }
+  ) {
+    name
+    symbol
+    metadata_reliability_score
+  }
+}
+```
+
+## Data Encoding Formats
+
+### Address Encoding
+
+Addresses in the GraphQL API are always returned as strings in hex format with 0x prefix:
+
+- **EVM Addresses**: `0x` + 40 hex characters
+- **Example**: `0x00000000000000000000000000000000002cc823`
+
+### Numeric Values
+
+Large numbers (balances, token supplies) are returned as strings to preserve precision:
+
+- **Format**: Decimal string representation
+- **Example**: `"1000000000000000000"` (1 token with 18 decimals)
+- **Max Value**: Full uint256 range (2^256 - 1)
+
+### Timestamps
+
+Two timestamp formats are used:
+
+| Field Type | Format | Example | Description |
+|------------|--------|---------|-------------|
+| created_timestamp | Nanoseconds | `1698765432100000000` | Hedera consensus time |
+| balance_timestamp | Nanoseconds | `1698765432100000000` | Last balance update |
+| processing_timestamp | Seconds | `1698765432` | Unix timestamp |
+
+To convert nanoseconds to a readable date:
+```javascript
+const date = new Date(nanoseconds / 1000000);
+```
+
+## Working with Token Balances
+
+### ERC-20 Balances
+
+Balances are stored in the smallest unit (wei):
+
+```javascript
+// Convert balance to human-readable format
+function formatBalance(balance, decimals) {
+  return (BigInt(balance) / BigInt(10 ** decimals)).toString();
+}
+
+// Example: 1000000000000000000 with 18 decimals = 1 token
+```
+
+### ERC-721 Balances
+
+For NFTs, the balance represents the count of NFTs owned:
+
+```graphql
+query NFTCount($accountId: bigint!, $tokenId: bigint!) {
+  erc_beta_token_account(
+    where: {
+      account_id: { _eq: $accountId }
+      token_id: { _eq: $tokenId }
+    }
+  ) {
+    balance  # This is the NFT count, not wei
+  }
+}
+```
+
+## Best Practices
+
+### Query Optimization
+
+1. **Use indexes**: Filter by indexed fields like `token_id`, `account_id`
+2. **Limit results**: Always use `limit` for large result sets
+3. **Select only needed fields**: Don't query unnecessary data
+
+### Handling Large Numbers
+
+Always use appropriate libraries for handling uint256 values:
+
+```javascript
+// JavaScript with BigInt
+const balance = BigInt("1000000000000000000");
+
+// ethers.js
+import { BigNumber } from "ethers";
+const balance = BigNumber.from("1000000000000000000");
+```
+
+### Account Resolution
+
+When working with addresses:
+
+1. Check if it's a long-zero address (12 leading zeros)
+2. If yes, extract the account ID directly
+3. If no, it's an EVM alias that needs resolution
+
+```javascript
+function isLongZeroAddress(address) {
+  return address.startsWith("0x000000000000000000000000");
+}
+
+function extractAccountId(longZeroAddress) {
+  // Extract last 8 bytes and convert to account number
+  const hex = longZeroAddress.slice(-8);
+  return parseInt(hex, 16);
+}
+```

--- a/docs/erc-token-data/token-types.md
+++ b/docs/erc-token-data/token-types.md
@@ -1,10 +1,17 @@
 ---
 sidebar_position: 4
+title: ERC vs HTS (Token Types)
 ---
 
 # Token Types
 
 Understanding the distinction between pure ERC tokens and HTS tokens is crucial when working with token data on Hedera.
+
+:::info In Beta → Hgraph's Hedera ERC Token Data
+
+This new data service is currently in beta and we encourage all users to provide feedback. Please [contact us to share your input](../overview/contact.md).
+
+:::
 
 ## What is HTS?
 
@@ -17,6 +24,7 @@ Hedera Token Service (HTS) is a native token system that provides token function
 These are standard smart contracts deployed directly to Hedera's EVM, just like on Ethereum or other EVM-compatible chains.
 
 **Characteristics:**
+
 - Smart contracts deployed directly to the EVM
 - Generate real Transfer events from contract code execution
 - NOT found in Hedera's native token registry
@@ -24,6 +32,7 @@ These are standard smart contracts deployed directly to Hedera's EVM, just like 
 - Examples: amWHBAR, amUSDC, Aave-style tokens deployed on Hedera
 
 **EVM Addresses:**
+
 - May have leading zeros (e.g., `0x00000000000000000000000000000000002cc823`)
 - Standard 20-byte Ethereum addresses
 
@@ -32,6 +41,7 @@ These are standard smart contracts deployed directly to Hedera's EVM, just like 
 These are native Hedera tokens that can be accessed through EVM precompiles to provide ERC compatibility.
 
 **Characteristics:**
+
 - Native Hedera Token Service tokens
 - Created through Hedera's native token APIs
 - Can be accessed via smart contracts using HIP-218/376 precompiles
@@ -40,6 +50,7 @@ These are native Hedera tokens that can be accessed through EVM precompiles to p
 - Examples: USDC (0.0.456858), WHBAR (0.0.1456986), KARATE, HST
 
 **Special Addresses:**
+
 - Use derived "long-zero" addresses (entity ID padded with 24 zeros)
 - Example: Token 0.0.456858 → `0x0000000000000000000000000000000006f89a`
 
@@ -48,6 +59,7 @@ These are native Hedera tokens that can be accessed through EVM precompiles to p
 ### Identifying HTS Tokens
 
 HTS tokens have these characteristics:
+
 - Have a Hedera token ID (e.g., 0.0.456858)
 - Use 8-byte topic format consistently in events
 - Events emitted via precompile mechanism
@@ -57,6 +69,7 @@ HTS tokens have these characteristics:
 ### Identifying Pure ERC Tokens
 
 Pure ERC tokens have these characteristics:
+
 - Only exist as smart contracts on the EVM
 - Use various topic formats in events
 - Events emitted directly from contract code
@@ -84,7 +97,7 @@ Pure ERC tokens have these characteristics:
 ```graphql
 query GetPureERC20Tokens {
   erc_beta_token(
-    where: { 
+    where: {
       contract_type: { _eq: "ERC_20" }
       # These are pure ERC tokens deployed as smart contracts
     }
@@ -101,29 +114,29 @@ query GetPureERC20Tokens {
 
 ### Common Pure ERC Tokens on Hedera
 
-| Token | Contract Address | Type |
-|-------|-----------------|------|
+| Token   | Contract Address                             | Type   |
+| ------- | -------------------------------------------- | ------ |
 | amWHBAR | `0x00000000000000000000000000000000002cc823` | ERC-20 |
-| amUSDC | `0x00000000000000000000000000000000002cc824` | ERC-20 |
+| amUSDC  | `0x00000000000000000000000000000000002cc824` | ERC-20 |
 
 ### Common HTS Tokens (Not in this dataset)
 
-| Token | Hedera ID | Long-zero Address | Type |
-|-------|-----------|-------------------|------|
-| USDC | 0.0.456858 | `0x0000000000000000000000000000000006f89a` | HTS with ERC facade |
+| Token | Hedera ID   | Long-zero Address                            | Type                |
+| ----- | ----------- | -------------------------------------------- | ------------------- |
+| USDC  | 0.0.456858  | `0x0000000000000000000000000000000006f89a`   | HTS with ERC facade |
 | WHBAR | 0.0.1456986 | `0x000000000000000000000000000000000016375a` | HTS with ERC facade |
 
 ## Topic Format Variations
 
 When analyzing Transfer events, Hedera account IDs can appear in different formats:
 
-| Length | Format | Description | Example (Account 924713) |
-|--------|--------|-------------|---------------------------|
-| 3 bytes (6 hex) | Compressed | Accounts < 16.7M | `0x0e1c29` |
-| 4 bytes (8 hex) | Padded | Larger accounts | `0x000e1c29` |
-| 8 bytes (16 hex) | HTS Standard | HTS format | `0x00000000000e1c29` |
-| 20 bytes (40 hex) | EVM Address | EVM-native | `0x3a6bef9dc803206a...` |
-| 32 bytes (64 hex) | Full Padding | Ethereum style | `0x000000...000e1c29` |
+| Length            | Format       | Description      | Example (Account 924713) |
+| ----------------- | ------------ | ---------------- | ------------------------ |
+| 3 bytes (6 hex)   | Compressed   | Accounts < 16.7M | `0x0e1c29`               |
+| 4 bytes (8 hex)   | Padded       | Larger accounts  | `0x000e1c29`             |
+| 8 bytes (16 hex)  | HTS Standard | HTS format       | `0x00000000000e1c29`     |
+| 20 bytes (40 hex) | EVM Address  | EVM-native       | `0x3a6bef9dc803206a...`  |
+| 32 bytes (64 hex) | Full Padding | Ethereum style   | `0x000000...000e1c29`    |
 
 Pure ERC tokens typically use the 20-byte or 32-byte formats, while HTS tokens consistently use the 8-byte format.
 

--- a/docs/erc-token-data/token-types.md
+++ b/docs/erc-token-data/token-types.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 4
+---
+
+# Token Types
+
+Understanding the distinction between pure ERC tokens and HTS tokens is crucial when working with token data on Hedera.
+
+## What is HTS?
+
+Hedera Token Service (HTS) is a native token system that provides token functionality at the protocol level. HTS tokens have built-in features like KYC, freeze, and custom fees that don't require smart contract deployment.
+
+## Two Types of ERC-Compatible Tokens on Hedera
+
+### 1. Pure ERC Tokens (Tracked by this Indexer)
+
+These are standard smart contracts deployed directly to Hedera's EVM, just like on Ethereum or other EVM-compatible chains.
+
+**Characteristics:**
+- Smart contracts deployed directly to the EVM
+- Generate real Transfer events from contract code execution
+- NOT found in Hedera's native token registry
+- Follow standard ERC-20/721 implementations
+- Examples: amWHBAR, amUSDC, Aave-style tokens deployed on Hedera
+
+**EVM Addresses:**
+- May have leading zeros (e.g., `0x00000000000000000000000000000000002cc823`)
+- Standard 20-byte Ethereum addresses
+
+### 2. HTS Tokens with ERC Facades (Not Included)
+
+These are native Hedera tokens that can be accessed through EVM precompiles to provide ERC compatibility.
+
+**Characteristics:**
+- Native Hedera Token Service tokens
+- Created through Hedera's native token APIs
+- Can be accessed via smart contracts using HIP-218/376 precompiles
+- Emit standard ERC events when called via smart contracts
+- When executed via HAPI (non-EVM), mirror nodes emit synthetic logs to mimic ERC events
+- Examples: USDC (0.0.456858), WHBAR (0.0.1456986), KARATE, HST
+
+**Special Addresses:**
+- Use derived "long-zero" addresses (entity ID padded with 24 zeros)
+- Example: Token 0.0.456858 → `0x0000000000000000000000000000000006f89a`
+
+## How to Identify Token Types
+
+### Identifying HTS Tokens
+
+HTS tokens have these characteristics:
+- Have a Hedera token ID (e.g., 0.0.456858)
+- Use 8-byte topic format consistently in events
+- Events emitted via precompile mechanism
+- Have native Hedera features (KYC, freeze, custom fees)
+- Can be found in Hedera's token registry
+
+### Identifying Pure ERC Tokens
+
+Pure ERC tokens have these characteristics:
+- Only exist as smart contracts on the EVM
+- Use various topic formats in events
+- Events emitted directly from contract code
+- Standard ERC-20/721 smart contract implementations
+- No native Hedera token ID
+
+## Why This Distinction Matters
+
+### For Developers
+
+1. **Different APIs**: HTS tokens can be queried through native Hedera APIs, while pure ERC tokens require EVM/contract queries
+2. **Event Structure**: Event topic formats differ between the two types
+3. **Feature Set**: HTS tokens have additional native features not available to pure ERC tokens
+
+### For Users
+
+1. **Wallet Support**: Some wallets may handle HTS tokens differently than pure ERC tokens
+2. **Transaction Fees**: HTS token operations may have different fee structures
+3. **Compliance Features**: HTS tokens can have built-in KYC and freeze capabilities
+
+## Examples
+
+### Pure ERC-20 Token Query
+
+```graphql
+query GetPureERC20Tokens {
+  erc_beta_token(
+    where: { 
+      contract_type: { _eq: "ERC_20" }
+      # These are pure ERC tokens deployed as smart contracts
+    }
+    limit: 10
+  ) {
+    token_id
+    name
+    symbol
+    decimals
+    evm_address
+  }
+}
+```
+
+### Common Pure ERC Tokens on Hedera
+
+| Token | Contract Address | Type |
+|-------|-----------------|------|
+| amWHBAR | `0x00000000000000000000000000000000002cc823` | ERC-20 |
+| amUSDC | `0x00000000000000000000000000000000002cc824` | ERC-20 |
+
+### Common HTS Tokens (Not in this dataset)
+
+| Token | Hedera ID | Long-zero Address | Type |
+|-------|-----------|-------------------|------|
+| USDC | 0.0.456858 | `0x0000000000000000000000000000000006f89a` | HTS with ERC facade |
+| WHBAR | 0.0.1456986 | `0x000000000000000000000000000000000016375a` | HTS with ERC facade |
+
+## Topic Format Variations
+
+When analyzing Transfer events, Hedera account IDs can appear in different formats:
+
+| Length | Format | Description | Example (Account 924713) |
+|--------|--------|-------------|---------------------------|
+| 3 bytes (6 hex) | Compressed | Accounts < 16.7M | `0x0e1c29` |
+| 4 bytes (8 hex) | Padded | Larger accounts | `0x000e1c29` |
+| 8 bytes (16 hex) | HTS Standard | HTS format | `0x00000000000e1c29` |
+| 20 bytes (40 hex) | EVM Address | EVM-native | `0x3a6bef9dc803206a...` |
+| 32 bytes (64 hex) | Full Padding | Ethereum style | `0x000000...000e1c29` |
+
+Pure ERC tokens typically use the 20-byte or 32-byte formats, while HTS tokens consistently use the 8-byte format.
+
+## Summary
+
+The Hedera ERC Indexer specifically tracks **pure ERC tokens** - standard smart contracts deployed to Hedera's EVM. These tokens follow the same patterns as ERC tokens on Ethereum and other EVM chains. HTS tokens, while offering ERC compatibility through precompiles, are native Hedera tokens with additional features and are not included in this dataset.
+
+When querying the GraphQL API, all tokens returned are pure ERC implementations, ensuring consistent behavior and standard ERC interfaces.

--- a/docs/graphql-api/common-queries.md
+++ b/docs/graphql-api/common-queries.md
@@ -148,6 +148,10 @@ A very common piece of data needed by developers is knowing whether a certain ac
 
 This function allows developers to easily determine association by passing in the account id and token id in question.
 
+:::tip ERC Token Queries
+For comprehensive queries specific to ERC-20 and ERC-721 tokens deployed on Hedera's EVM, see our dedicated [ERC Token Data queries](/erc-token-data/queries) section which includes portfolio tracking, NFT collections, and token analytics.
+:::
+
 ```javascript
 // Sense if an account has associated the token id.
 // If not, create transactions and send to client

--- a/docs/graphql-api/overview.md
+++ b/docs/graphql-api/overview.md
@@ -25,3 +25,7 @@ REST APIs use multiple endpoints and standard HTTP methods, with the server dete
 ## Playground access
 
 To explore the API schema and try out different queries, you can [access our playground console here](https://console.hgraph.io/).
+
+## Specialized Data Access
+
+For comprehensive ERC-20 and ERC-721 token data on Hedera, see our dedicated [ERC Token Data](/category/erc-token-data) section which provides specialized queries and schemas for pure ERC token contracts.

--- a/docs/overview/services.md
+++ b/docs/overview/services.md
@@ -19,6 +19,7 @@ Hgraph provides data infrastructure for web3 applications. Current services and 
 
 ### Hedera APIs:
 - GraphQL, REST, JSON-RPC relay
+- ERC-20 & ERC-721 token data
 - 3rd party integrations & tooling
 - Account dashboard, playground
 - Helpful SDKs, documentation

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -23,6 +23,7 @@ Create new GraphQL queries and troubleshoot problems with our new expert AI assi
 - **[AI Assistant](https://dashboard.hgraph.com)** - Create queries and troubleshoot issues.
 - **[Pricing](/overview/pricing)** - Start for free, upgrade later (starting at $18/mo).
 - [GraphQL API](/category/graphql-api) - Access data on the Hedera mirror nodes.
+- [ERC Token Data](/category/erc-token-data) - Access pure ERC-20 and ERC-721 token data on Hedera.
 - [Hgraph SDK](/category/hgraph-sdk) - Build data-rich apps and experiences.
 - [GitHub](https://github.com/hgraph-io) - Follow Hgraph on GitHub and contribute.
 - [Support](/support) - Get assistance from our team & community.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for Hgraph's Hedera ERC Token Data service, providing access to pure ERC-20 and ERC-721 token data through the GraphQL API.

## Changes

### New Documentation Section
- **Overview**: Introduction to the ERC indexer and quick start guide
- **Schema Reference**: Detailed field descriptions for `erc_beta` tables
- **Token Types**: Explains distinction between pure ERC tokens and HTS tokens
- **Technical Details**: Event signatures, account identifiers, data pipeline overview
- **Query Examples**: 15+ GraphQL query examples with real-world use cases

### Cross-References Added
- Added ERC Token Data to welcome page quick links
- Updated GraphQL API overview with specialized data access section
- Added reference in GraphQL common queries
- Updated services page to include ERC token data

## Testing
- All markdown files pass linting
- Cross-references verified
- GraphQL queries tested against API