### PR TITLE
Add documentation for HBAR Total Supply metric

### DIFF
--- a/docs/hedera-stats/hbar-defi/hbar-total-supply.md
+++ b/docs/hedera-stats/hbar-defi/hbar-total-supply.md
@@ -1,0 +1,114 @@
+---
+sidebar_position: 2
+title: HBAR Total Supply
+---
+
+# HBAR Total Supply
+
+## Overview
+The HBAR Total Supply statistic represents the fixed, pre-minted supply of HBAR tokens on the Hedera network. At network genesis, exactly 50 billion HBAR were created, establishing the maximum supply that will ever exist. This immutable value is fundamental to understanding Hedera's tokenomics and economic model.
+
+:::note Hedera Data Access
+To access this Hedera network statistic ([and others](/category/hedera-stats/)) via Hgraph's GraphQL & REST APIs, [get started here](https://www.hgraph.com/hedera).
+:::
+
+Hedera Stat Name: **`hbar_total_supply`**
+
+## Methodology
+- **Fixed Supply:** 50 billion HBAR (5,000,000,000,000,000,000 tinybars) pre-minted at network genesis
+- **Implementation:**
+  - This value is hardcoded in the Hedera Mirror Node (`NetworkSupplyViewModel.totalSupply`)
+  - Cannot change without unanimous consent of the Hedera Council
+  - Stored as a static metric in the ecosystem.metric table for efficient querying
+
+- **Important Note:**
+  - When summing all entity balances dynamically, the result is 49,999,943,600 HBAR
+  - The missing 56,400 HBAR exists at the protocol level, outside any account
+  - This discrepancy is why a static approach is preferred over dynamic calculation
+
+## Data Representation
+The total supply metric is stored with entries for all time periods (minute, hour, day, week, month, quarter, year) to provide flexibility in user queries. The timestamp range spans from genesis (September 1, 2019) to a future date, where the upper bound can be interpreted as "last verified."
+
+Since this is a constant value, all queries will return the same result regardless of the time period or date range specified.
+
+## Additional Notes
+- The total supply is a cornerstone metric for calculating circulating supply, market capitalization, and other economic indicators
+- The value is represented in tinybars in the database (1 HBAR = 100,000,000 tinybars)
+- Future protocol changes requiring unanimous Hedera Council approval could theoretically modify this value, though this is extremely unlikely
+
+## GraphQL API Examples
+
+Test out these queries using our [developer playground](https://dashboard.hgraph.com).
+
+### Fetch HBAR total supply
+
+```graphql
+query GetHBARTotalSupply {
+  metric: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_supply"}}
+    limit: 1
+  ) {
+    total
+    end_date
+  }
+}
+```
+
+### Fetch total supply with specific period
+
+```graphql
+query GetHBARTotalSupplyDaily {
+  metric: ecosystem_metric(
+    where: {
+      name: {_eq: "hbar_total_supply"}
+      period: {_eq: "day"}
+    }
+    limit: 1
+  ) {
+    total
+    start_date
+    end_date
+  }
+}
+```
+
+### Convert to HBAR units
+
+```graphql
+query GetHBARTotalSupplyFormatted {
+  metric: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_supply"}}
+    limit: 1
+  ) {
+    total_tinybars: total
+  }
+}
+```
+
+> **Note:** Divide the `total` response by `100000000` to convert from tinybars to HBAR. The result will always be 50,000,000,000 HBAR.
+
+## Available Time Periods
+
+The `period` field supports the following values:
+
+- `minute`
+- `hour`
+- `day`
+- `week`
+- `month`
+- `quarter`
+- `year`
+
+All periods return the same constant value. Multiple periods are provided for query flexibility and compatibility with time-series analysis tools.
+
+## SQL Implementation
+
+Below is a link to the **Hedera Stats** GitHub repository. The repo contains the SQL function that populates the **HBAR Total Supply** statistic outlined in this methodology.
+
+SQL File: `src/metrics/hbar-defi/hbar_total_supply.sql`
+
+**[View GitHub Repository →](https://github.com/hgraph-io/hedera-stats)**
+
+## Dependencies
+* Hedera mirror node (for context and validation)
+* No external APIs or dynamic calculations required


### PR DESCRIPTION
## Summary
- Add comprehensive documentation page for the `hbar_total_supply` metric
- Document the fixed 50 billion HBAR supply and implementation details
- Include GraphQL API examples and usage instructions

## Changes
- Created `docs/hedera-stats/hbar-defi/hbar-total-supply.md` with:
  - Overview of the 50 billion HBAR pre-minted supply
  - Methodology explaining the hardcoded Mirror Node implementation
  - Documentation of the 56,400 HBAR protocol-level discrepancy
  - GraphQL API examples for querying the metric
  - All 7 available time periods documented
  - Link to GitHub repository SQL implementation

## Context
This documentation complements the recently added `hbar_total_supply` metric in the Hedera Stats repository (PR #57). It provides users with clear guidance on:
- Understanding why HBAR total supply is a fixed constant
- How to query the metric via GraphQL
- Why all time periods are available for user convenience
- The technical details behind the implementation

## Testing
- Documentation follows the same format as other Hedera Stats pages
- GraphQL examples are consistent with existing patterns
- Sidebar position (2) places it logically between HBAR Price and Stablecoin Market Cap