### PR TITLE
docs: add HBAR total released metric documentation

### DIFF
--- a/docs/hedera-stats/hbar-defi/_category_.json
+++ b/docs/hedera-stats/hbar-defi/_category_.json
@@ -3,6 +3,6 @@
   "position": 4,
   "link": {
     "type": "generated-index",
-    "description": "HBAR pricing data and decentralized finance (DeFi) metrics including Total Value Locked (TVL) and stablecoin market capitalization on the Hedera network."
+    "description": "HBAR supply and pricing data, and decentralized finance (DeFi) metrics including Total Value Locked (TVL) and stablecoin market capitalization on the Hedera network."
   }
 }

--- a/docs/hedera-stats/hbar-defi/hbar-total-released.md
+++ b/docs/hedera-stats/hbar-defi/hbar-total-released.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 3
+title: HBAR Total Released
+---
+
+# HBAR Total Released
+
+## Overview
+The HBAR Total Released statistic represents the circulating (released) supply of HBAR tokens on the Hedera network. This metric tracks the amount of HBAR that has been released from treasury accounts into circulation since network genesis. Unlike the fixed total supply of 50 billion HBAR, the released supply changes over time as treasury accounts distribute or reclaim HBAR, providing a dynamic view of the actual circulating tokens available in the ecosystem.
+
+:::note Hedera Data Access
+To access this Hedera network statistic ([and others](/category/hedera-stats/)) via Hgraph's GraphQL & REST APIs, [get started here](https://www.hgraph.com/hedera).
+:::
+
+Hedera Stat Name: **`hbar_total_released`**
+
+## Methodology
+
+- **Calculation Formula:** Released Supply = Total Supply (50B HBAR) - Unreleased Supply
+- **Alternative Formula:** Released Supply = Total Supply + Cumulative Net Treasury Flows
+- **Implementation:**
+  - Tracks cumulative net flows from 548 designated treasury/system accounts since genesis
+  - Uses the `crypto_transfer` table to maintain complete historical accuracy
+  - Negative flows from treasury accounts represent releases into circulation
+  - Positive flows to treasury accounts represent returns from circulation
+
+- **Treasury Accounts Tracked (548 total):**
+  - 0.0.2: Primary Hedera Treasury account
+  - 0.0.42: System account
+  - 0.0.44-71: 28 system accounts
+  - 0.0.73-87: 15 system accounts
+  - 0.0.99-100: 2 system accounts
+  - 0.0.200-349: 150 reserved accounts
+  - 0.0.400-750: 351 reserved accounts
+
+- **Flow Mechanics:**
+  - Outflows (negative amounts) from treasury = HBAR releases into circulation
+  - Inflows (positive amounts) to treasury = HBAR removed from circulation
+  - Cumulative calculation ensures historical accuracy from genesis
+
+## Data Representation
+
+The released supply metric provides a time-series view of HBAR circulation from network genesis (September 16, 2019) to present. Each data point represents the total released supply at that moment in time, calculated as the cumulative sum of all treasury flows up to that point.
+
+The metric is stored for multiple time periods (day, week, month, quarter, year) to support various analysis needs. Values are stored in tinybars for precision (1 HBAR = 100,000,000 tinybars).
+
+## Additional Notes
+
+- The released supply is essential for calculating accurate market capitalization and understanding true token circulation
+- At genesis (Sept 16, 2019), approximately 46.95 billion HBAR were initially released
+- As of late 2024, approximately 42.39 billion HBAR are in circulation
+- The metric updates automatically via scheduled job procedures
+- Processing the full history from genesis takes approximately 3-5 seconds
+- Results can be cross-referenced with the Mirror Node API endpoint `/api/v1/network/supply`
+
+## GraphQL API Examples
+
+Test out these queries using our [developer playground](https://dashboard.hgraph.com).
+
+### Fetch current released supply
+
+```graphql
+query GetCurrentReleasedSupply {
+  metric: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_released"}, period: {_eq: "day"}}
+    order_by: {end_date: desc_nulls_last}
+    limit: 1
+  ) {
+    total
+    end_date
+  }
+}
+```
+
+### Fetch daily released supply (timeseries, 30 days)
+
+```graphql
+query GetDailyReleasedSupply {
+  metric: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_released"}, period: {_eq: "day"}}
+    order_by: {end_date: desc_nulls_last}
+    limit: 30
+  ) {
+    total
+    start_date
+    end_date
+  }
+}
+```
+
+### Fetch weekly supply changes (52 weeks)
+
+```graphql
+query GetWeeklySupplyChanges {
+  metric: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_released"}, period: {_eq: "week"}}
+    order_by: {end_date: desc_nulls_last}
+    limit: 52
+  ) {
+    total
+    start_date
+    end_date
+  }
+}
+```
+
+### Calculate circulating percentage of total supply
+
+```graphql
+query GetSupplyPercentage {
+  released: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_released"}}
+    order_by: {end_date: desc_nulls_last}
+    limit: 1
+  ) {
+    total
+  }
+  total: ecosystem_metric(
+    where: {name: {_eq: "hbar_total_supply"}}
+    limit: 1
+  ) {
+    total
+  }
+}
+```
+
+> **Note:** Divide the `total` response by `100000000` to convert from tinybars to HBAR. For example, a value of 4239292654349979588 tinybars equals approximately 42,392,926,543.50 HBAR.
+
+## Available Time Periods
+
+The `period` field supports the following values:
+
+- `day`
+- `week`
+- `month`
+- `quarter`
+- `year`
+
+Each period provides cumulative released supply data aggregated at that time interval, enabling both detailed and high-level analysis of supply dynamics.
+
+## SQL Implementation
+
+Below is a link to the **Hedera Stats** GitHub repository. The repo contains the SQL function that calculates the **HBAR Total Released** statistic outlined in this methodology.
+
+SQL File: `src/metrics/hbar-defi/hbar_total_released.sql`
+
+**[View GitHub Repository →](https://github.com/hgraph-io/hedera-stats)**
+
+## Dependencies
+
+- Hedera mirror node (primary data source)
+- `crypto_transfer` table for historical treasury flow tracking
+- `ecosystem.metric` table for storing calculated results
+- Scheduled job procedures for automated updates

--- a/docs/hedera-stats/hbar-defi/hbar-total-supply.md
+++ b/docs/hedera-stats/hbar-defi/hbar-total-supply.md
@@ -32,7 +32,7 @@ The total supply metric is stored with entries for all time periods (minute, hou
 Since this is a constant value, all queries will return the same result regardless of the time period or date range specified.
 
 ## Additional Notes
-- The total supply is a cornerstone metric for calculating circulating supply, market capitalization, and other economic indicators
+- The total supply is a cornerstone metric for calculating released supply (see [hbar_total_released](/hedera-stats/hbar-defi/hbar-total-released)), market capitalization, and other economic indicators
 - The value is represented in tinybars in the database (1 HBAR = 100,000,000 tinybars)
 - Future protocol changes requiring unanimous Hedera Council approval could theoretically modify this value, though this is extremely unlikely
 

--- a/docs/hedera-stats/introduction.md
+++ b/docs/hedera-stats/introduction.md
@@ -50,6 +50,8 @@ A breakdown of all available Hedera Stats on mainnet. Each link will take you to
 ### HBAR & DeFi
 
 - [HBAR Price](/hedera-stats/hbar-defi/hbar-price): `avg_usd_conversion`
+- [HBAR Total Supply](/hedera-stats/hbar-defi/hbar-total-supply): `hbar_total_supply`
+- [HBAR Total Released](/hedera-stats/hbar-defi/hbar-total-released): `hbar_total_released`
 - [Total Value Locked](/hedera-stats/hbar-defi/total-value-locked): `network_tvl`
 - [Stablecoin Market Cap](/hedera-stats/hbar-defi/stablecoin-market-cap): `stablecoin_marketcap`
 


### PR DESCRIPTION
## Summary
Adds comprehensive documentation for the new `hbar_total_released` metric to track HBAR circulating/released supply.

## Changes
- **New documentation page**: `docs/hedera-stats/hbar-defi/hbar-total-released.md`
  - Complete methodology explanation
  - GraphQL API examples
  - Treasury account details (548 accounts tracked)
  - Additional notes section with key metrics

- **Updated existing pages**:
  - `introduction.md`: Added both `hbar_total_supply` and `hbar_total_released` to HBAR & DeFi section
  - `_category_.json`: Updated description to mention HBAR supply metrics
  - `hbar-total-supply.md`: Added cross-reference to the new released supply metric

## Related PRs
- Code implementation: hgraph-io/hedera-stats#58

## Technical Details
The `hbar_total_released` metric:
- Tracks cumulative net flows from 548 designated treasury/system accounts
- Calculates: Released Supply = Total Supply (50B HBAR) + Cumulative Treasury Flows
- Returns values in tinybars (1 HBAR = 100,000,000 tinybars)
- Supports daily, weekly, monthly, quarterly, and yearly periods
- Enables backfilling from network genesis (Sept 16, 2019)

## Test Plan
- [ ] Verify documentation builds correctly
- [ ] Check all internal links work
- [ ] Confirm GraphQL examples are accurate
- [ ] Review formatting and consistency with existing docs