### PR TITLE
fix: correct HBAR price multiplier in documentation

### DIFF
--- a/docs/hedera-stats/hbar-defi/hbar-price.md
+++ b/docs/hedera-stats/hbar-defi/hbar-price.md
@@ -18,7 +18,7 @@ Hedera Stat Name: **`avg_usd_conversion`**
 - **Data Sources:** Binance, Bybit, OKX, Bitget and MEXC
 - **Aggregation:**
   - The average of candlestick closing prices for a given period for the HBAR/USDT pair on the five major exchanges by trading volume was calculated.
-  - The price is multiplied by 10,000 for integer representation for each time period.
+  - The price is multiplied by 100,000 for integer representation for each time period.
 
 ## Data Representation
 Each period represents the latest available HBAR price at the given timestamp. This metric is useful for tracking price fluctuations and market trends.


### PR DESCRIPTION
Fixes incorrect price multiplier in hbar-price.md documentation.

The avg_usd_conversion metric stores price × 100,000 (not 10,000).
This corrects the documentation to match the actual implementation in the SQL functions.

Note: The division instruction (divide by 100000) was already correct.