### PR TITLE
Update avg_time_to_consensus documentation to reflect ETL implementation

### DIFF
--- a/docs/hedera-stats/installation.md
+++ b/docs/hedera-stats/installation.md
@@ -14,7 +14,7 @@ This documentation contains the information needed to re-create Hedera Stats usi
 - **[Hedera Stats GitHub Repository](https://github.com/hgraph-io/hedera-stats)**
 - **Hedera Mirror Node** or access to **Hgraph's GraphQL API**
   - [Create a free account](https://hgraph.com/hedera)
-- **Prometheus** (`promtool`) for `avg_time_to_consensus` ([view docs](https://prometheus.io/docs/introduction/overview/))
+- **Prometheus** (`promtool`) for `avg_time_to_consensus` ETL pipeline ([view docs](https://prometheus.io/docs/introduction/overview/))
 - **PostgreSQL database** needed for SQL script execution ([view docs](https://www.postgresql.org/docs/current/))
 - **DeFiLlama API** for decentralized finance metrics ([view docs](https://defillama.com/docs/api)).
 
@@ -48,13 +48,19 @@ Configure environment variables (example `.env`):
 ```env
 DATABASE_URL="postgresql://user:password@localhost:5432/hedera_stats"
 HGRAPH_API_KEY="your_api_key"
+# Required for avg_time_to_consensus ETL pipeline
+PROMETHEUS_ENDPOINT="https://your-prometheus-endpoint"
+POSTGRES_CONNECTION_STRING="postgresql://user:password@localhost:5432/hedera_stats"
 ```
 
 Schedule incremental updates:
 
 ```bash
 crontab -e
+# Time-to-consensus (hourly)
 1 * * * * cd /path/to/hedera-stats/src/time-to-consensus && bash ./run.sh >> ./.raw/cron.log 2>&1
+# Time-to-consensus (daily)
+2 0 * * * cd /path/to/hedera-stats/src/time-to-consensus && bash ./run_day.sh >> ./.raw/cron_day.log 2>&1
 ```
 
 ## Troubleshooting & FAQs

--- a/docs/hedera-stats/misc.md
+++ b/docs/hedera-stats/misc.md
@@ -68,4 +68,4 @@ These stats provide insight into the overall network activity and economic indic
 | `network_tvl`              | Total value locked (TVL) in USD within Hedera's ecosystem. |
 | `stablecoin_marketcap`            | Total market capitalization (USD) of all stablecoins on Hedera (e.g., USDC, USDT). |
 | `avg_usd_conversion`              | Average HBAR to USD conversion rate (multiplied by 100,000 for integer representation). |
-| `avg_time_to_consensus`       | Average time (in nanoseconds) for transactions to reach consensus. |
+| `avg_time_to_consensus`       | Average SecC2RC time (in nanoseconds) - elapsed time from consensus to record creation. |


### PR DESCRIPTION
## Summary

Updates documentation to accurately reflect the current avg_time_to_consensus metric implementation using ETL pipeline instead of SQL functions.

## Changes

- **time-to-consensus.md**: Complete methodology rewrite with ETL pipeline details, Prometheus integration, and daily period support
- **installation.md**: Added dual cron setup and required environment variables for ETL pipeline
- **misc.md**: Corrected metric description to reflect SecC2RC timing

## Impact

Documentation now matches the actual implementation from hedera-stats PR #63, providing accurate setup instructions and API examples for both hourly and daily periods.